### PR TITLE
PHP 8.2 support: dynamic properties no longer supported, unless extending stdClass

### DIFF
--- a/src/Pushbullet/Device.php
+++ b/src/Pushbullet/Device.php
@@ -7,7 +7,7 @@ namespace Pushbullet;
  *
  * @package Pushbullet
  */
-class Device
+class Device extends stdClass
 {
     use Pushable;
 

--- a/src/Pushbullet/Device.php
+++ b/src/Pushbullet/Device.php
@@ -7,7 +7,7 @@ namespace Pushbullet;
  *
  * @package Pushbullet
  */
-class Device extends stdClass
+class Device extends \stdClass
 {
     use Pushable;
 


### PR DESCRIPTION
Deprecation warning is triggered by the setting of properties in the construct function.